### PR TITLE
load model to device when not use tp and fsdp

### DIFF
--- a/diffsynth_engine/pipelines/base.py
+++ b/diffsynth_engine/pipelines/base.py
@@ -214,6 +214,21 @@ class BasePipeline:
         return self
 
     @staticmethod
+    def get_init_device(
+        parallelism: int,
+        use_cfg_parallel: bool,
+        model_config: ModelConfig,
+        device: str,
+    ) -> str:
+        if parallelism == 1:
+            return device
+        tp_degree = getattr(model_config, "tp_degree", None)
+        use_fsdp = getattr(model_config, "use_fsdp", False)
+        if use_fsdp or (tp_degree is not None and tp_degree > 1):
+            return "cpu"
+        return device
+
+    @staticmethod
     def init_parallel_config(
         parallelism: int,
         use_cfg_parallel: bool,

--- a/diffsynth_engine/pipelines/flux_image.py
+++ b/diffsynth_engine/pipelines/flux_image.py
@@ -545,7 +545,10 @@ class FluxImagePipeline(BasePipeline):
             logger.info(f"loading state dict from {model_config.t5_path} ...")
             t5_state_dict = cls.load_model_checkpoint(model_config.t5_path, device="cpu", dtype=dtype)
 
-        init_device = "cpu" if parallelism > 1 or offload_mode is not None else device
+        if offload_mode is not None:
+            init_device = "cpu"
+        else:
+            init_device = cls.get_init_device(parallelism, use_cfg_parallel, model_config, device)
         if load_text_encoder:
             tokenizer = CLIPTokenizer.from_pretrained(FLUX_TOKENIZER_1_CONF_PATH)
             tokenizer_2 = T5TokenizerFast.from_pretrained(FLUX_TOKENIZER_2_CONF_PATH)


### PR DESCRIPTION
在某些特定的机器上，spawn pickle 内存数据时可能内存不对齐，会导致 AVX2 指令集 copy 数据时报错 bus error。
将 tensor 转到 gpu 显存上，避免走 AVX2 数据拷贝，且能节省一次内存间的拷贝