### PR TITLE
implement ring attention

### DIFF
--- a/diffsynth_engine/configs/base.py
+++ b/diffsynth_engine/configs/base.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Tuple
 import torch
 
 from diffsynth_engine.layers.attention import AttentionType
+from diffsynth_engine.layers.attention.ring import RING_ATTN_COMPATIBLE_TYPES
 from diffsynth_engine.utils import logging
 
 logger = logging.get_logger(__name__)
@@ -56,6 +57,7 @@ class PipelineConfig:
 
     def __post_init__(self):
         init_parallel_config(self)
+        validate_ring_attention_config(self)
 
 
 def init_parallel_config(config: PipelineConfig):
@@ -96,3 +98,12 @@ def init_parallel_config(config: PipelineConfig):
         if not config.vae_tiled:
             config.vae_tiled = True
             logger.warning("setting vae_tiled to True since use_vae_parallel is enabled")
+
+
+def validate_ring_attention_config(config) -> None:
+    if config.sp_ring_degree is not None and config.sp_ring_degree > 1:
+        if config.attn_type not in RING_ATTN_COMPATIBLE_TYPES:
+            raise ValueError(
+                f"attention backend {config.attn_type} does not support ring attention "
+                f"(missing forward_with_lse). Use one of: {', '.join(str(t) for t in RING_ATTN_COMPATIBLE_TYPES)}"
+            )

--- a/diffsynth_engine/distributed/parallel_state.py
+++ b/diffsynth_engine/distributed/parallel_state.py
@@ -737,6 +737,11 @@ def destroy_model_parallel():
         _VAE.destroy()
     _VAE = None
 
+    global _DIT
+    if _DIT is not None:
+        torch.distributed.destroy_process_group(_DIT)
+    _DIT = None
+
 
 def destroy_distributed_environment():
     global _WORLD

--- a/diffsynth_engine/layers/attention/backends/aiter.py
+++ b/diffsynth_engine/layers/attention/backends/aiter.py
@@ -71,6 +71,24 @@ class AiterImpl(AttentionImpl):
         )
         return output
 
+    def forward_with_lse(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        output, lse = aiter_flash_attn(
+            query,
+            key,
+            value,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
+            return_lse=True,
+        )
+        return output, lse
+
 
 class AiterFP8Backend(AiterBackend):
     @staticmethod
@@ -104,4 +122,29 @@ class AiterFP8Impl(AiterImpl):
             softmax_scale=self.softmax_scale,
         )
         output = output.to(original_dtype)
+        return output
+
+    def forward_with_lse(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        # TODO: scaling
+        original_dtype = query.dtype
+        query = query.to(DTYPE_FP8)
+        key = key.to(DTYPE_FP8)
+        value = value.to(DTYPE_FP8)
+        output, lse = aiter_flash_attn_fp8(
+            query,
+            key,
+            value,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
+            return_lse=True,
+        )
+        output = output.to(original_dtype)
+        lse = lse.to(original_dtype)
         return output

--- a/diffsynth_engine/layers/attention/backends/aiter.py
+++ b/diffsynth_engine/layers/attention/backends/aiter.py
@@ -78,7 +78,7 @@ class AiterImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata | None = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         output, lse = aiter_flash_attn(
             query,
             key,

--- a/diffsynth_engine/layers/attention/backends/aiter.py
+++ b/diffsynth_engine/layers/attention/backends/aiter.py
@@ -131,7 +131,7 @@ class AiterFP8Impl(AiterImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata | None = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # TODO: scaling
         original_dtype = query.dtype
         query = query.to(DTYPE_FP8)
@@ -147,4 +147,4 @@ class AiterFP8Impl(AiterImpl):
         )
         output = output.to(original_dtype)
         lse = lse.to(original_dtype)
-        return output
+        return output, lse

--- a/diffsynth_engine/layers/attention/backends/flash_attn_2.py
+++ b/diffsynth_engine/layers/attention/backends/flash_attn_2.py
@@ -90,3 +90,43 @@ class FlashAttention2Impl(AttentionImpl):
                 window_size=window_size if window_size is not None else (-1, -1),
             )
         return output
+
+    def forward_with_lse(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: torch.Tensor | None = None,
+        cu_seqlens_k: torch.Tensor | None = None,
+        max_seqlen_q: int | None = None,
+        max_seqlen_k: int | None = None,
+        window_size: Tuple[int, int] | None = None,
+        attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if cu_seqlens_q is not None:
+            output, lse, *_ = flash_attn_varlen_func(
+                query,
+                key,
+                value,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                window_size=window_size if window_size is not None else (-1, -1),
+                return_attn_probs=True,
+            )
+        else:
+            output, lse, *_ = flash_attn_func(
+                query,
+                key,
+                value,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                window_size=window_size if window_size is not None else (-1, -1),
+                return_attn_probs=True,
+            )
+
+        return output, lse

--- a/diffsynth_engine/layers/attention/backends/flash_attn_3.py
+++ b/diffsynth_engine/layers/attention/backends/flash_attn_3.py
@@ -92,6 +92,45 @@ class FlashAttention3Impl(AttentionImpl):
             )
         return output
 
+    def forward_with_lse(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: torch.Tensor | None = None,
+        cu_seqlens_k: torch.Tensor | None = None,
+        max_seqlen_q: int | None = None,
+        max_seqlen_k: int | None = None,
+        window_size: Tuple[int, int] | None = None,
+        attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if cu_seqlens_q is not None:
+            output, lse, *_ = flash_attn_varlen_func(
+                query,
+                key,
+                value,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                window_size=window_size if window_size is not None else (-1, -1),
+                return_attn_probs=True,
+            )
+        else:
+            output, lse, *_ = flash_attn_func(
+                query,
+                key,
+                value,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                window_size=window_size if window_size is not None else (-1, -1),
+                return_attn_probs=True,
+            )
+        return output, lse
+
 
 class FlashAttention3FP8Backend(FlashAttention3Backend):
     @staticmethod
@@ -146,3 +185,47 @@ class FlashAttention3FP8Impl(FlashAttention3Impl):
             )
         output = output.to(original_dtype)
         return output
+
+    def forward_with_lse(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: torch.Tensor | None = None,
+        cu_seqlens_k: torch.Tensor | None = None,
+        max_seqlen_q: int | None = None,
+        max_seqlen_k: int | None = None,
+        window_size: Tuple[int, int] | None = None,
+        attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        original_dtype = query.dtype
+        query = query.to(DTYPE_FP8)
+        key = key.to(DTYPE_FP8)
+        value = value.to(DTYPE_FP8)
+        if cu_seqlens_q is not None:
+            output, lse, *_ = flash_attn_varlen_func(
+                query,
+                key,
+                value,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                window_size=window_size if window_size is not None else (-1, -1),
+                return_attn_probs=True,
+            )
+        else:
+            output, lse, *_ = flash_attn_func(
+                query,
+                key,
+                value,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                window_size=window_size if window_size is not None else (-1, -1),
+                return_attn_probs=True,
+            )
+        output = output.to(original_dtype)
+        return output, lse

--- a/diffsynth_engine/layers/attention/backends/flash_attn_4.py
+++ b/diffsynth_engine/layers/attention/backends/flash_attn_4.py
@@ -90,3 +90,42 @@ class FlashAttention4Impl(AttentionImpl):
                 window_size=window_size if window_size is not None else (-1, -1),
             )
         return output
+
+    def forward_with_lse(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: torch.Tensor | None = None,
+        cu_seqlens_k: torch.Tensor | None = None,
+        max_seqlen_q: int | None = None,
+        max_seqlen_k: int | None = None,
+        window_size: Tuple[int, int] | None = None,
+        attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if cu_seqlens_q is not None:
+            output, lse, *_ = flash_attn_varlen_func(
+                query,
+                key,
+                value,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                max_seqlen_q,
+                max_seqlen_k,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                window_size=window_size if window_size is not None else (-1, -1),
+                return_lse=True,
+            )
+        else:
+            output, lse, *_ = flash_attn_func(
+                query,
+                key,
+                value,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+                window_size=window_size if window_size is not None else (-1, -1),
+                return_lse=True,
+            )
+        return output, lse

--- a/diffsynth_engine/layers/attention/backends/sage_attn_2.py
+++ b/diffsynth_engine/layers/attention/backends/sage_attn_2.py
@@ -91,3 +91,33 @@ class SageAttention2Impl(AttentionImpl):
             )
         output = rearrange(output, "b n s d -> b s n d")
         return output
+
+    def forward_with_lse(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens_q: torch.Tensor | None = None,
+        cu_seqlens_k: torch.Tensor | None = None,
+        max_seqlen_q: int | None = None,
+        max_seqlen_k: int | None = None,
+        attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        query = rearrange(query, "b s n d -> b n s d")
+        key = rearrange(key, "b s n d -> b n s d")
+        value = rearrange(value, "b s n d -> b n s d")
+
+        if cu_seqlens_q is not None:
+            raise NotImplementedError("sageattn_varlen can not return lse.")
+        else:
+            output, lse = sageattn(
+                query,
+                key,
+                value,
+                is_causal=self.causal,
+                sm_scale=self.softmax_scale,
+                return_lse=True,
+            )
+        output = rearrange(output, "b n s d -> b s n d")
+        return output, lse

--- a/diffsynth_engine/layers/attention/backends/sage_attn_2.py
+++ b/diffsynth_engine/layers/attention/backends/sage_attn_2.py
@@ -103,7 +103,7 @@ class SageAttention2Impl(AttentionImpl):
         max_seqlen_k: int | None = None,
         attn_metadata: AttentionMetadata | None = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         query = rearrange(query, "b s n d -> b n s d")
         key = rearrange(key, "b s n d -> b n s d")
         value = rearrange(value, "b s n d -> b n s d")

--- a/diffsynth_engine/layers/attention/backends/sdpa.py
+++ b/diffsynth_engine/layers/attention/backends/sdpa.py
@@ -83,7 +83,7 @@ class SDPAImpl(AttentionImpl):
         attn_mask: torch.Tensor | None = None,
         attn_metadata: AttentionMetadata | None = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         query = rearrange(query, "b s n d -> b n s d")
         key = rearrange(key, "b s n d -> b n s d")
         value = rearrange(value, "b s n d -> b n s d")

--- a/diffsynth_engine/layers/attention/backends/sdpa.py
+++ b/diffsynth_engine/layers/attention/backends/sdpa.py
@@ -9,6 +9,8 @@ from diffsynth_engine.layers.attention.backends.abstract import (
     AttentionType,
 )
 
+_scaled_dot_product_efficient_attention = torch.ops.aten._scaled_dot_product_efficient_attention
+
 
 class SDPABackend(AttentionBackend):
     @staticmethod
@@ -72,3 +74,36 @@ class SDPAImpl(AttentionImpl):
         )
         output = rearrange(output, "b n s d -> b s n d")
         return output
+
+    def forward_with_lse(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+        attn_metadata: AttentionMetadata | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        query = rearrange(query, "b s n d -> b n s d")
+        key = rearrange(key, "b s n d -> b n s d")
+        value = rearrange(value, "b s n d -> b n s d")
+
+        if self.num_kv_groups > 1:
+            key = torch.repeat_interleave(key, self.num_kv_groups, dim=1)
+            value = torch.repeat_interleave(value, self.num_kv_groups, dim=1)
+
+        seq_len = query.shape[2]
+        output, lse = _scaled_dot_product_efficient_attention(
+            query,
+            key,
+            value,
+            attn_bias=attn_mask,
+            compute_log_sumexp=True,
+            is_causal=self.causal,
+            scale=self.softmax_scale,
+        )[:2]
+
+        output = rearrange(output, "b n s d -> b s n d")
+        # the returned lse is padded but not restored, so we need to slice it
+        lse = lse[:, :, :seq_len]
+        return output, lse

--- a/diffsynth_engine/layers/attention/layer.py
+++ b/diffsynth_engine/layers/attention/layer.py
@@ -149,7 +149,7 @@ class USPAttention(nn.Module):
 
         if ring_parallel_world_size > 1:
             # warning: attn_kwargs is not supported for ring flash attention
-            output = ring_flash_attention_forward(q, k, v, self.attn_impl)
+            output = ring_flash_attention_forward(q, k, v, self.attn_impl, **attn_kwargs)
         else:
             output = self.attn_impl.forward(q, k, v, **attn_kwargs)
 

--- a/diffsynth_engine/layers/attention/ring.py
+++ b/diffsynth_engine/layers/attention/ring.py
@@ -1,6 +1,20 @@
 import torch
+import torch.nn.functional as F
 
-from diffsynth_engine.layers.attention.backends.abstract import AttentionImpl
+from diffsynth_engine.distributed.comm import RingComm
+from diffsynth_engine.distributed.parallel_state import get_sp_group
+from diffsynth_engine.layers.attention.backends.abstract import AttentionImpl, AttentionType
+
+RING_ATTN_COMPATIBLE_TYPES = frozenset(
+    {
+        AttentionType.SDPA,
+        AttentionType.FA2,
+        AttentionType.FA3,
+        AttentionType.FA3_FP8,
+        AttentionType.FA4,
+        AttentionType.SAGE2,
+    }
+)
 
 
 def ring_flash_attention_forward(
@@ -8,6 +22,74 @@ def ring_flash_attention_forward(
     key: torch.Tensor,
     value: torch.Tensor,
     attn_impl: AttentionImpl,
-):
-    # TODO: implement ring flash attention
-    raise NotImplementedError("Ring Flash Attention is not supported yet")
+    **kwargs,
+) -> torch.Tensor:
+    """Ring Flash Attention: each rank attends its local Q to all K/V shards across
+    the ring, overlapping the next step's K/V transfer with the current attention compute.
+
+    Args:
+        query: [B, S/P, H, D] local query shard.
+        key:   [B, S/P, H, D] local key shard.
+        value: [B, S/P, H, D] local value shard.
+        attn_impl: AttentionImpl backend (e.g. FlashAttention2Impl).
+
+    Returns:
+        [B, S/P, H, D] attention output for the local query shard.
+    """
+    sp_group = get_sp_group()
+    comm = RingComm(sp_group.ring_group)
+    world_size = comm.world_size
+
+    out = None
+    lse = None
+
+    key = key.contiguous()
+    value = value.contiguous()
+
+    for step in range(world_size):
+        if step + 1 < world_size:
+            next_key = comm.send_recv(key)
+            next_value = comm.send_recv(value)
+            comm.commit()
+
+        block_out, block_lse = attn_impl.forward_with_lse(query, key, value, **kwargs)
+        out, lse = _update_out_and_lse(out, lse, block_out, block_lse)
+
+        if step + 1 < world_size:
+            comm.wait()
+            key = next_key
+            value = next_value
+
+    return out.to(query.dtype)
+
+
+def _update_out_and_lse(
+    out: torch.Tensor | None,
+    lse: torch.Tensor | None,
+    out_block: torch.Tensor,
+    lse_block: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sigmoid-form merge for out and lse.
+    Reference: https://github.com/zhuzilin/ring-flash-attention/pull/34#issuecomment-2076126795
+
+    Args:
+        out:       [B, S_q, H, D] running attention output of Q over all K/V shards merged so far,
+                   or None on the first step.
+        lse:       [B, S_q, H, 1] running log-sum-exp of attention scores over those same shards,
+                   in broadcast layout. None on the first step.
+        out_block: [B, S_q, H, D] attention output of Q over the current K/V shard only.
+        lse_block: [B, H, S_q] log-sum-exp of attention scores over the current K/V shard only
+                   (native attn impl layout, transposed inside).
+
+    Returns:
+        out: [B, S_q, H, D] new running attention output, now including the current shard.
+        lse: [B, S_q, H, 1] new running log-sum-exp, now including the current shard.
+    """
+    lse_block = lse_block.transpose(1, 2).unsqueeze(-1)
+    if out is None:
+        return out_block.float(), lse_block
+
+    out_block = out_block.float()
+    out = out - F.sigmoid(lse_block - lse) * (out - out_block)
+    lse = lse - F.logsigmoid(lse - lse_block)
+    return out, lse

--- a/tests/test_pipelines/test_qwen_image_usp.py
+++ b/tests/test_pipelines/test_qwen_image_usp.py
@@ -1,0 +1,48 @@
+import unittest
+
+import torch
+
+from diffsynth_engine import DiffSynthEngine
+from diffsynth_engine.configs import QwenImagePipelineConfig
+from diffsynth_engine.utils.download import fetch_model
+from tests.common.test_case import ImageTestCase
+
+
+class TestQwenImagePipelineUSP(ImageTestCase):
+    """2x2 sequence parallelism: ulysses=2 + ring=2 (4 GPUs)."""
+
+    @classmethod
+    def setUpClass(cls):
+        model_path = fetch_model("Qwen/Qwen-Image")
+        config = QwenImagePipelineConfig(
+            model_path=model_path,
+            parallelism=4,
+            sp_ulysses_degree=2,
+            sp_ring_degree=2,
+        )
+        cls.engine = DiffSynthEngine.from_pretrained(config)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine.shutdown()
+        del cls.engine
+        torch.cuda.empty_cache()
+
+    def test_txt2img_sp_2x2(self):
+        prompt = "A painting of a cat in a zen garden"
+        negative_prompt = "ugly, blurry, low quality"
+        output = self.engine.generate(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            true_cfg_scale=4.0,
+            width=1328,
+            height=1328,
+            num_inference_steps=28,
+            generator=torch.Generator(device="cpu").manual_seed(42),
+        )
+        image = output.images[0]
+        self.assertImageEqualAndSaveFailed(image, "qwen_image/qwen_image.png", threshold=0.99)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces support for ring-based flash attention in the DiffSynthEngine, enabling distributed attention computation across multiple devices. It adds the ring flash attention implementation, integrates it with compatible attention backends, and ensures correct configuration and validation. Additionally, the PR introduces a new test for Qwen-Image pipeline with 2x2 sequence parallelism. The most important changes are:

**Ring Flash Attention Implementation and Integration:**

* Added an initial implementation of ring flash attention in `ring.py`, including the `ring_flash_attention_forward` function and a merging strategy for distributed attention outputs. Also defined `RING_ATTN_COMPATIBLE_TYPES` to specify which attention types support ring attention.
* Updated the attention layer to use `ring_flash_attention_forward` with additional keyword arguments, enabling support for ring-based distributed attention in the main attention layer logic.
* Imported `RING_ATTN_COMPATIBLE_TYPES` in the config and added a validation function to ensure only compatible attention backends are used with ring attention. The validation is invoked during pipeline config initialization. [[1]](diffhunk://#diff-c8c81b9c447d6d449960154ee5cac5bf5ac547da3984b59172d8dd23ad289eb8R7) [[2]](diffhunk://#diff-c8c81b9c447d6d449960154ee5cac5bf5ac547da3984b59172d8dd23ad289eb8R60) [[3]](diffhunk://#diff-c8c81b9c447d6d449960154ee5cac5bf5ac547da3984b59172d8dd23ad289eb8R101-R109)

**Attention Backend Enhancements:**

* Implemented the `forward_with_lse` method in multiple attention backends (`aiter.py`, `flash_attn_2.py`, `flash_attn_3.py`, `flash_attn_4.py`, `sage_attn_2.py`, `sdpa.py`) to enable computation of both attention outputs and log-sum-exp values, which are required for ring attention merging. [[1]](diffhunk://#diff-38579c83d859fc693fb9ebeffecca6ec7b226d8f0bb7edf78462a7a64cf1e8b8R74-R91) [[2]](diffhunk://#diff-38579c83d859fc693fb9ebeffecca6ec7b226d8f0bb7edf78462a7a64cf1e8b8R126-R150) [[3]](diffhunk://#diff-72a48a7e82c68ee061f41833d4dcb79287850b7f93afeb84c626faccb47da285R93-R132) [[4]](diffhunk://#diff-eaee25095b12a3e5b43a3d66a0db6840ec010df5542b09f3acd43aafa7d8a506R95-R133) [[5]](diffhunk://#diff-eaee25095b12a3e5b43a3d66a0db6840ec010df5542b09f3acd43aafa7d8a506R188-R231) [[6]](diffhunk://#diff-d97919836e768124df9862343fac83ddcb9d592aac0547018b2228b1afbbe6d4R93-R131) [[7]](diffhunk://#diff-1f7f1085db699df69f4551abb14a380c75778499551c5d793cf71950f3dd470bR94-R123) [[8]](diffhunk://#diff-661947d1e6e3b40cefe3952e9671f690a5358d4bcc93c1ace0bc65f43e6b5863R12-R13) [[9]](diffhunk://#diff-661947d1e6e3b40cefe3952e9671f690a5358d4bcc93c1ace0bc65f43e6b5863R77-R109)

**Distributed State Management:**

* Ensured proper cleanup of the distributed process group for the ring parallelism context by updating the `destroy_model_parallel` function.

**Testing:**

* Added a new test case for the Qwen-Image pipeline with 2x2 sequence parallelism (ulysses=2, ring=2), verifying end-to-end functionality of the new distributed attention mechanism.