### PR TITLE
performance(ring para): change sdpa backend to flash attention

### DIFF
--- a/diffsynth_engine/layers/attention/backends/sdpa.py
+++ b/diffsynth_engine/layers/attention/backends/sdpa.py
@@ -9,7 +9,7 @@ from diffsynth_engine.layers.attention.backends.abstract import (
     AttentionType,
 )
 
-_scaled_dot_product_efficient_attention = torch.ops.aten._scaled_dot_product_efficient_attention
+_scaled_dot_product_flash_attention = torch.ops.aten._scaled_dot_product_flash_attention
 
 
 class SDPABackend(AttentionBackend):
@@ -88,6 +88,12 @@ class SDPAImpl(AttentionImpl):
         attn_metadata: AttentionMetadata | None = None,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if attn_mask is not None:
+            raise NotImplementedError(
+                "SDPA forward_with_lse does not support attn_mask; "
+                "masked Ring attention is not supported"
+            )
+
         query = rearrange(query, "b s n d -> b n s d")
         key = rearrange(key, "b s n d -> b n s d")
         value = rearrange(value, "b s n d -> b n s d")
@@ -96,18 +102,15 @@ class SDPAImpl(AttentionImpl):
             key = torch.repeat_interleave(key, self.num_kv_groups, dim=1)
             value = torch.repeat_interleave(value, self.num_kv_groups, dim=1)
 
-        seq_len = query.shape[2]
-        output, lse = _scaled_dot_product_efficient_attention(
+        output, lse = _scaled_dot_product_flash_attention(
             query,
             key,
             value,
-            attn_bias=attn_mask,
-            compute_log_sumexp=True,
+            dropout_p=0.0,
             is_causal=self.causal,
+            return_debug_mask=False,
             scale=self.softmax_scale,
         )[:2]
 
         output = rearrange(output, "b n s d -> b s n d")
-        # the returned lse is padded but not restored, so we need to slice it
-        lse = lse[:, :, :seq_len]
         return output, lse


### PR DESCRIPTION
# Description

When using the sdpa attention backend with ring sp, this pr replaces efficient backend with flash backend to accelerate.

# Related Issue

#266 

# Test Env

| config | val |
|--------|-----|
| Python / PyTorch | 3.12.13 / 2.11.0+cu130 |
| CUDA / NCCL | 13.0 / 2.28.9 |
| Diffusers / Transformers | 0.36.0 / 4.57.6 |
| GPU | 4 x NVIDIA RTX PRO 5000 72GB Blackwell，driver 580.159.03 |
| Attention backend | DiffSynth `sdpa` |
| Dtype |  BF16 |
| Picture | 1024 x 1024，1 per prompt |
| Denoise | 5 steps，CFG scale 4.0，seed 42 |
| Prompt | `A red fox sitting beside a mountain lake at sunrise, highly detailed` |
| Negative prompt | `blurry, low quality` |






# Precision
| | Cosine | Normalized SSIM | PSNR | MAE / 255 | Max abs |
| --- |  ---: | ---: | ---: | ---: | ---: |
| flash CP2 vs efficient CP2 | 0.997295 | 0.969289 | 28.049 dB | 4.750 / 255 | 196 |
| flash CP2 vs SP2 |  0.997394 | 0.969862 | 28.226 dB | 4.501 / 255 | 187 |
| efficient CP2 vs SP2 |  0.997398 | 0.970382 | 28.218 dB | 4.571 / 255 | 180 |



From tables above, we can conclude that comparing to efficient CP2, flash ring CP2 achieves comparable precision to ulysses SP2.


# Throughput

| mode | Request wall time | Denoise stage | steady step |
| --- | ---: | ---: | ---: |
|  Flash CP2 | **2.946104 +/- 0.010519 s** | **2750.312 +/- 12.587 ms** | **550.423 +/- 2.351 ms** |
| SP2 | 3.145325 +/- 0.011289 s | 2951.521 +/- 12.741 ms | 590.334 +/- 2.524 ms |
|  Efficient CP2 | 3.459390 +/- 0.025342 s | 3260.770 +/- 19.557 ms | 652.187 +/- 4.197 ms |